### PR TITLE
fix(ansible-role): use default branch

### DIFF
--- a/.github/workflows/ansible-role.yaml
+++ b/.github/workflows/ansible-role.yaml
@@ -15,3 +15,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.1
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          git_branch: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
This PR makes sure that the ansible-role workflow always  uses the default branch instead of the hardcoded default of `master`.