### PR TITLE
fix: update the defaults because of missing image tags

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -20,7 +20,7 @@ on:
               },
               {
                 "image": "fedora",
-                "tag": "40"
+                "tag": "latest"
               },
               {
                 "image": "fedora",
@@ -28,7 +28,7 @@ on:
               },
               {
                 "image": "ubuntu",
-                "tag": "noble"
+                "tag": "latest"
               },
               {
                 "image": "ubuntu",


### PR DESCRIPTION
This is needed because the defaults didn't have matching tags of Roberts images.