### PR TITLE
chore(ci): semrel tagFormat remove v-prefix

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -23,3 +23,4 @@ jobs:
         with:
           allow-initial-development-versions: true
           github-token: ${{ secrets.ADFINISBOT_GITHUB_TOKEN }}
+          custom-arguments: "--provider-opt='strip_v_tag_prefix=true'"


### PR DESCRIPTION
removes the default v-prefix, to be compliant with regular Ansible Galaxy releases.