### PR TITLE
feat: workflow ansible-galaxy-role-release

### DIFF
--- a/.github/workflows/ansible-galaxy-role-release.yaml
+++ b/.github/workflows/ansible-galaxy-role-release.yaml
@@ -1,0 +1,31 @@
+---
+
+name: Release Ansible role to Ansible Galaxy
+
+on:
+  workflow_call:
+    secrets:
+      galaxy_api_key:
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible
+        run: pip3 install ansible-core
+
+      - name: Trigger a new import on Galaxy
+        run: >-
+          ansible-galaxy role import
+          --api-key ${{ secrets.galaxy_api_key }}
+          --branch ${{ github.event.repository.default_branch }}
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)


### PR DESCRIPTION
no "official" Ansible Galaxy role release action available, so building a new workflow, based on an example from https://github.com/geerlingguy/ansible-role-dotfiles/blob/master/.github/workflows/release.yml