### PR TITLE
chore(molecule): add fedora 40/41, drop 39

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -24,7 +24,7 @@ on:
               },
               {
                 "image": "fedora",
-                "tag": "39"
+                "tag": "40"
               },
               {
                 "image": "ubuntu",


### PR DESCRIPTION
Bareos supports Fedora 41 now and dropped support for Fedora 39 in https://download.bareos.org/current/