### PR TITLE
chore(molecule) switch to ansible/ansible-lint

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -40,12 +40,12 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    name: Ansible Lint
+    runs-on: ubuntu-24.04
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: ansible-lint
-        uses: ansible-community/ansible-lint-action@main
+      - uses: actions/checkout@v4
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main
   test:
     needs:
       - lint


### PR DESCRIPTION
Use ansible/ansible-lint instead of ansible-community/ansible-lint-action as the other is deprecated.

Refs: https://github.com/ansible/ansible-lint-action