### PR TITLE
fix(ci): molecule debian trixie to 'latest'

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -12,7 +12,7 @@ on:
             "config": [
               {
                 "image": "debian",
-                "tag": "trixie"
+                "tag": "latest"
               },
               {
                 "image": "debian",


### PR DESCRIPTION
no tag "trixie" available, just "latest"